### PR TITLE
Implement `fcb`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,8 +15,41 @@ struct Cli {
     code: Option<String>,
 }
 
-pub fn run() -> Result<(), io::Error> {
+#[derive(Debug)]
+pub enum FcbError {
+    CannotReadStdin(io::Error),
+}
+
+impl std::fmt::Display for FcbError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FcbError::CannotReadStdin(err) => {
+                write!(f, "{PROGRAM}: failed to read stdin: {}", err)
+            }
+        }
+    }
+}
+
+impl std::error::Error for FcbError {}
+
+pub fn run() -> Result<(), FcbError> {
     let cli = Cli::parse();
-    Ok(())
+    let code = match cli.code {
+        Some(code) => Ok(code),
+        None => read_from_stdin().map_err(FcbError::CannotReadStdin),
+    }?;
+
+}
+
+fn read_from_stdin() -> io::Result<String> {
+    let mut stdin = io::stdin();
+
+    if stdin.is_terminal() {
+        return Ok("".to_string());
+    }
+
+    let mut buf = String::new();
+    let _ = stdin.read_to_string(&mut buf)?;
+    Ok(buf)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,6 @@ use std::io::{self, IsTerminal, Read, Write};
 
 use clap::Parser;
 
-const PROGRAM: &str = "fcb";
-
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Cli {
@@ -23,12 +21,13 @@ pub enum FcbError {
 
 impl std::fmt::Display for FcbError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let program = "fcb";
         match self {
             FcbError::CannotReadStdin(err) => {
-                write!(f, "{PROGRAM}: failed to read stdin: {}", err)
+                write!(f, "{program}: failed to read stdin: {}", err)
             }
             FcbError::CannotWriteStdout(err) => {
-                write!(f, "{PROGRAM}: failed to write stdout: {}", err)
+                write!(f, "{program}: failed to write stdout: {}", err)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,14 @@
-pub fn render(lang: Option<String>, code: Option<String>) -> String {
-    todo!()
+pub fn render(lang: &Option<String>, code: &mut Option<String>) -> String {
+    let empty = "";
+
+    let lang = lang.as_ref().map(|val| val.as_str()).unwrap_or(empty);
+    let code = code
+        .as_mut()
+        .map(|val| {
+            val.push('\n');
+            val.as_str()
+        })
+        .unwrap_or(empty);
+
+    format!("```{}\n{}```", lang, code)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,55 @@ pub fn render(lang: &Option<String>, code: &mut Option<String>) -> String {
 
     format!("```{}\n{}```", lang, code)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_render_without_any_args() {
+        let lang: Option<String> = None;
+        let mut code: Option<String> = None;
+
+        let result = render(&lang, &mut code);
+
+        assert_eq!(result, "```\n```".to_string());
+    }
+
+    #[test]
+    fn should_render_with_lang() {
+        let test_lang = "rust";
+        let lang: Option<String> = Some(test_lang.to_string());
+        let mut code: Option<String> = None;
+
+        let result = render(&lang, &mut code);
+        let expected = format!("```{}\n```", test_lang);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn should_render_code_with_newline() {
+        let test_code = "println!(\"Hello world!\")";
+        let mut code: Option<String> = Some(test_code.to_string());
+
+        let result = render(&None, &mut code);
+        let expected = format!("```\n{}\n```", test_code);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn should_render_with_lang_and_code() {
+        let test_lang = "rust";
+        let test_code = "println!(\"Hello world!\")";
+
+        let lang: Option<String> = Some(test_lang.to_string());
+        let mut code: Option<String> = Some(test_code.to_string());
+
+        let result = render(&lang, &mut code);
+        let expected = format!("```{}\n{}\n```", test_lang, test_code);
+
+        assert_eq!(result, expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,69 @@
+#![warn(missing_docs)]
+//! Generates fenced code blocks.
+
+/// `render` is used to create a String that represents a code block.
+///
+/// `lang`: It is used to decorate the code block to enable syntax highlighting.
+///
+/// `code`: It is used as the code block's content.
+///
+/// # Details
+///
+/// By default, `render` uses empty `&str` for arguments that are `None`.
+///
+/// When `code` is `Some`, then `render` adds a trailing newline to it.
+/// Therefore, users do not need to add a trailing newline to their `code`.
+///
+/// # Examples
+///
+/// With `lang` and `code`:
+///
+/// ```
+/// let mut code = Some("println!(\"Hello world!\");".to_string());
+/// let lang = Some("rust".to_string());
+///
+/// let code_block = fcb::render(&lang, &mut code);
+/// println!("{}", code_block);
+/// // Output:
+/// // ```rust
+/// // println!("Hello world!");
+/// // ```
+/// ```
+///
+/// With `lang` only:
+///
+/// ```
+/// let lang = Some("rust".to_string());
+///
+/// let code_block = fcb::render(&lang, &mut None);
+/// println!("{}", code_block);
+/// // Output:
+/// // ```rust
+/// // ```
+/// ```
+///
+/// With `code` only:
+///
+/// ```
+/// let mut code = Some("println!(\"Hello world!\");".to_string());
+///
+/// let code_block = fcb::render(&None, &mut code);
+/// println!("{}", code_block);
+/// // Output:
+/// // ```
+/// // println!("Hello world!");
+/// // ```
+/// ```
+///
+/// With nothing provided:
+///
+/// ```
+/// let code_block = fcb::render(&None, &mut None);
+/// println!("{}", code_block);
+/// // Output:
+/// // ```
+/// // ```
+/// ```
 pub fn render(lang: &Option<String>, code: &mut Option<String>) -> String {
     let empty = "";
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,108 @@
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        io::{self, Write},
+        process::{Command, Stdio},
+        thread,
+    };
+
+    #[test]
+    fn write_empty_lang_empty_code_block_to_stdout() -> io::Result<()> {
+        let fcb_path = fs::canonicalize("./target/debug/fcb")?;
+
+        let fcb_out = Command::new(fcb_path).output()?;
+        let expected_stdout = "```\n```";
+
+        assert!(fcb_out.status.success());
+        assert_eq!(fcb_out.stdout, expected_stdout.as_bytes());
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_empty_lang_nonempty_code_block_to_stdout() -> io::Result<()> {
+        let fcb_path = fs::canonicalize("./target/debug/fcb")?;
+
+        let code = "println!(\"Hello world!\");";
+
+        let fcb_out = Command::new(fcb_path).arg(code).output()?;
+        let expected_stdout = format!("```\n{}\n```", code);
+
+        assert!(fcb_out.status.success());
+        assert_eq!(fcb_out.stdout, expected_stdout.as_bytes());
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_nonempty_lang_nonempty_code_block_to_stdout() -> io::Result<()> {
+        let fcb_path = fs::canonicalize("./target/debug/fcb")?;
+
+        let lang = "rust";
+        let code = "println!(\"Hello world!\");";
+
+        let fcb_out = Command::new(fcb_path)
+            .args(["-l", lang])
+            .arg(code)
+            .output()?;
+        let expected_stdout = format!("```{}\n{}\n```", lang, code);
+
+        assert!(fcb_out.status.success());
+        assert_eq!(fcb_out.stdout, expected_stdout.as_bytes());
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_stdin_errors_to_stderr() -> io::Result<()> {
+        let fcb_path = fs::canonicalize("./target/debug/fcb")?;
+
+        let mut fcb_handle = Command::new(fcb_path)
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let mut stdin = fcb_handle.stdin.take().expect("failed to bind to stdin");
+        thread::spawn(move || {
+            // NOTE: Invalid UTF-8 is written to stdin to trigger
+            // a read error inside the process.
+            let code = b"\xF09F";
+
+            stdin.write_all(code).expect("failed to write to stdin");
+        });
+
+        let fcb_out = fcb_handle.wait_with_output()?;
+
+        assert!(!fcb_out.status.success());
+        assert!(!fcb_out.stderr.is_empty());
+        assert!(fcb_out.stdout.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn write_stdout_errors_to_stderr() -> io::Result<()> {
+        let fcb_path = fs::canonicalize("./target/debug/fcb")?;
+
+        // SAFETY: The unsafe block below is intentional and safe to use.
+        // The goal is to pass an invalid UTF-8 String to make the process
+        // throw an error on stdout write, which expects a valid UTF-8 String.
+        //
+        // It is safe because the binding is not accessed on anywhere else,
+        // and the provided value is static. Therefore, it is guaranteed to
+        // create an invalid UTF-8 String (aka. no undefined behaviors).
+        let code = unsafe { String::from_utf8_unchecked(b"\xF09F".to_vec()) };
+
+        let fcb_out = Command::new(fcb_path)
+            .arg(code)
+            .stdout(Stdio::inherit())
+            .output()?;
+
+        assert!(!fcb_out.status.success());
+        assert!(!fcb_out.stderr.is_empty());
+        assert!(fcb_out.stdout.is_empty());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds the functionality of `fcb` on top of its designed API in #1.

The core functionality and the interaction with standard I/O streams (`stdin`, `stdout`, `stderr`) are secured with tests.

A documentation is also added for `fcb::render()`.

