### PR TITLE
Add pipelines to distribute `fcb`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: "fcb - CI"
-run-name: fcb - CI on {{ github.ref }} @{{ github.actor }}
+run-name: fcb - CI on ${{ github.ref }} @${{ github.actor }}
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Run clippy
         run: |
           ./exec lint
-        shell: /bin/bash
+        shell: bash
 
       - name: Run all tests
         run: |
           ./exec test
-        shell: /bin/bash
+        shell: bash
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: "fcb - CI"
+run-name: fcb - CI on {{ github.ref }} @{{ github.actor }}
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  ci:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run clippy
+        run: |
+          ./exec lint
+        shell: /bin/bash
+
+      - name: Run all tests
+        run: |
+          ./exec test
+        shell: /bin/bash
+        env:
+          RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: "fcb - Release"
+run-name: fcb - Release on {{ github.ref }}
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  create-release:
+    needs: ci
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact_upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+ 
+
+  publish-release-artifacts:
+    needs: create-release
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        build:
+          - x86_64 GNU Linux
+          - aarch64 Darwin
+        include:
+          - build: x86_64 GNU Linux
+            runs-on: ubuntu-24.04 
+            rust_target: x86_64-unknown-linux-gnu
+
+          - build: aarch64 Darwin
+            runs-on: macos-latest
+            rust_target: aarch64-apple-darwin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create archive
+        id: create-archive
+        env:
+          target: ${{ matrix.rust_target}}
+        run: |
+          name="fcb-$target"
+
+          ./exec create_archive "$target" "$name"
+
+          echo "name=$name.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Create checksum
+        id: create-checksum
+        env:
+          target: ${{ matrix.rust_target }}
+        run: |
+          # target="x86_64-unknown-linux-gnu"
+          name="fcb-$target"
+
+          ./exec create_checksum "$target" > "./target/$target/release/$name.sha256sum"
+          echo "name=$name.sha256sum" >> "$GITHUB_OUTPUT"
+
+      - name: Attach archive to release
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          target: ${{ matrix.rust_target }}
+          archive_name: ${{ steps.create-archive.output.name }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.artifact_upload_url }}
+          asset_path: "./target/$target/release/$archive_name"
+
+      - name: Attach checksum to release
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          target: ${{ matrix.rust_target }}
+          checksum_name: ${{ steps.create-checksum.output.name }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.artifact_upload_url }}
+          asset_path: "./target/$target/release/$checksum_name"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,17 @@
 [package]
 name = "fcb"
 version = "0.1.0"
+authors = ["Berk Acikgoz <acikgozb@proton.me>"]
 edition = "2024"
-description = "Generates fenced code blocks."
+description = "A command line utility for fenced code blocks."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/acikgozb/fcb"
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
+
+[profile.release]
+lto = true
+strip = true
+# Size > comp time for this program, hence the codegen flag.
+codegen-units = 1

--- a/exec
+++ b/exec
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+program="fcb-exec"
+
+function lint() {
+  check_extern_commands "cargo"
+  cargo clippy --no-deps
+}
+
+function test() {
+  check_extern_commands "cargo"
+  cargo test 
+}
+
+function check_extern_commands() {
+    for cmd in "${@}"; do
+    if ! which "$cmd" > /dev/null 2>&1; then 
+      echo "${program}: please install $cmd to proceed." >&2
+      exit 1
+    fi
+    done
+}
+
+"$@"
+
+

--- a/exec
+++ b/exec
@@ -4,6 +4,40 @@ set -euo pipefail
 
 program="fcb-exec"
 
+function create_archive() {
+  check_extern_commands "cargo" "tar"
+
+  target_os="$1"
+  program_name="$2"
+  target_dir="./target/$target_os/release"
+
+  if [ -d "./target/$target_os" ]; then
+      rm -rf "./target/$target_os"
+  fi
+
+  cargo build --release --locked --target "$target_os"
+  tar czvf "$target_dir/$program_name.tar.gz" "$target_dir/fcb"
+}
+
+function create_checksum() {
+  sha_cmd=""
+  sha_opts=()
+
+  if [ "$(uname -s)" == "Darwin" ]; then
+    sha_cmd="sha256sum"
+  else
+    sha_cmd="shasum"
+    sha_opts+=("-a" "256")
+  fi
+
+  check_extern_commands "cargo" "$sha_cmd"
+
+  target_os="$1"
+  target_dir="./target/$target_os/release"
+
+  "$sha_cmd" "${sha_opts[@]}" "$target_dir/fcb"
+}
+
 function lint() {
   check_extern_commands "cargo"
   cargo clippy --no-deps


### PR DESCRIPTION
This PR adds 2 simple pipelines to the repository:

- CI: For lint + tests (unit + e2e + doc)
- Release: To create a draft release on tag push, including the prebuilt binary + SHA256 checksum.

The prebuilt binary is built for the systems below (atleast for now):

- x86_64-unknown-linux-gnu
- aarch64-apple-darwin