### PR TITLE
fix: release: Install sha256sum to Darwin runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
           ./exec create_archive "$RUST_TARGET" "$path"
           echo "path=$path" >> "$GITHUB_OUTPUT"
 
+      - name: Install sha256sum for Darwin (coreutils)
+        if: ${{ matrix.runs-on == macos-latest }}
+        run: |
+          brew install coreutils
+
       - name: Create checksum
         id: create-checksum
         env:


### PR DESCRIPTION
By default, `sha256sum` does not exist on public GHA Darwin runner, `macos-latest`.

Therefore, `coreutils` is installed via `brew` as a workaround solution.