### PR TITLE
fix: archive: Fix `fcb` binary path in archive

### DIFF
--- a/exec
+++ b/exec
@@ -15,7 +15,7 @@ function create_archive() {
   fi
 
   cargo build --release --locked --target "$rust_target"
-  tar czvf "$archive_path" "./target/$rust_target/release/fcb"
+  tar -C "./target/$rust_target/release" -czvf "$archive_path" "fcb"
 }
 
 function create_checksum_darwin() {


### PR DESCRIPTION
Since the operations are done from the repository root, the binary path inside the archive was too nested and confusing.

Therefore, the `tar` command is changed to work on the inner directory, instead of the repository root.